### PR TITLE
Add Bower manifest

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,9 +3,9 @@ Copyright (c) 2014 Alfred Xing
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, and/or sublicense copies of
-the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,10 @@
+{
+    "name": "http.js",
+    "version": "0.1.0",
+    "main": "http.min.js",
+    "keywords": ["http", "AJAX", "XMLHttpRequest", "client-side"],
+    "license": "MIT",
+    "ignore": [
+        "html"
+    ]
+}


### PR DESCRIPTION
Adds a Bower manifest so users can `bower install git://github.com/wylst/http.js.git`.

@dbohdan How does this look?
